### PR TITLE
Register nested attributes

### DIFF
--- a/tests/test_name_visitor.py
+++ b/tests/test_name_visitor.py
@@ -31,7 +31,7 @@ examples = [
     ('x = y()', {'x', 'y'}),
     ('def example(): x = y(); z()', {'x', 'y', 'z'}),
     # Attribute
-    ('x.y', {'x'}),
+    ('x.y', {'x.y', 'x'}),
     (
         textwrap.dedent(
             """
@@ -55,7 +55,7 @@ examples = [
     b = a.y
     """
         ),
-        {'self', 'a', 'z', 'x', 13, 'b', 'Test'},
+        {'self.y', 'z', 'Test', 'self', 13, 'a', 'b', 'x', 'a.y'},
     ),
     (
         textwrap.dedent(
@@ -70,14 +70,14 @@ examples = [
     (
         textwrap.dedent(
             """
-    import ast
-    def _get_usages(example):
-        visitor = UnusedImportVisitor()
-        visitor.visit(parse(example))
-        return visitor.usage_names
-    """
+        import ast
+        def _get_usages(example):
+            visitor = UnusedImportVisitor()
+            visitor.visit(parse(example))
+            return visitor.usage_names
+        """
         ),
-        {'visitor', 'UnusedImportVisitor', 'parse', 'example'},
+        {'UnusedImportVisitor', 'example', 'parse', 'visitor', 'visitor.usage_names', 'visitor.visit'},
     ),
 ]
 
@@ -103,4 +103,4 @@ def test_model_declarations_are_included_in_names():
         )
     """
     )
-    assert _get_names(example) == {'models', 'fk', 'SomeModel'}
+    assert _get_names(example) == {'SomeModel', 'fk', 'models', 'models.CASCADE', 'models.ForeignKey', 'models.Model'}

--- a/tests/test_tyo100.py
+++ b/tests/test_tyo100.py
@@ -9,6 +9,7 @@ One thing to note: The local/remote is a semi-arbitrary division and really just
     2. In the current working dir, but inside a venv
 
 """
+import textwrap
 
 import pytest
 
@@ -72,6 +73,7 @@ examples = [
     # ast.ImportFrom
     (f'from {mod} import Plugin\ndef example() -> Plugin:\n\tpass', {'1:0 ' + TYO100.format(module=f'{mod}.Plugin')}),
     # Aliased imports
+    (f'import {mod} as x\ndef example() -> x:\n\tpass', {'1:0 ' + TYO100.format(module=f'x')}),
     (f'import {mod} as x\ndef example() -> x:\n\tpass', {'1:0 ' + TYO100.format(module=f'x')}),
 ]
 

--- a/tests/test_tyo101.py
+++ b/tests/test_tyo101.py
@@ -119,6 +119,30 @@ examples = [
         ),
         set(),
     ),
+    (
+        textwrap.dedent(
+            '''
+            import proj.app.enums
+
+
+            class Migration:
+                enum=proj.app.enums
+            '''
+        ),
+        set(),
+    ),
+    (
+        textwrap.dedent(
+            '''
+            import proj.app.enums
+
+
+            class Migration:
+                enum=proj.app.enums.EnumClass
+            '''
+        ),
+        set(),
+    ),
 ]
 
 


### PR DESCRIPTION
Code like this

```python
import proj.app.enums

class Migration:
    enum=proj.app.enums.EnumClass
```

which is just a simplified example of a Django migration file, was flagging false positives.

The problem is that the current code does not register that `proj.app.enums.EnumClass` is related to the `proj.app.enums` import in any way. 

I'm not super excited about this way of solving the problem, but this fixes the test example without breaking the existing test suite. Any feedback here, on how it might be cleaned up is much appreciated @JonasKs 