### PR TITLE
Add TCH004 to warn about used type checking imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,32 +20,32 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
       - id: flake8
         additional_dependencies: [
-            'flake8-bugbear==20.11.1',
-            'flake8-comprehensions==3.3.1',
-            'flake8-quotes==3.2.0',
-            'flake8-tidy-imports==4.2.1',
-            'flake8-print==4.0.0',
-            'flake8-mutable==1.2.0',
-            'flake8-simplify==0.14.0',
-            'flake8-pytest-style==1.3.0',
-            'flake8-docstrings==1.5.0',
-            'flake8-annotations==2.5.0',
+            'flake8-bugbear',
+            'flake8-comprehensions',
+            'flake8-quotes',
+            'flake8-tidy-imports',
+            'flake8-print',
+            'flake8-mutable',
+            'flake8-simplify',
+            'flake8-pytest-style',
+            'flake8-docstrings',
+            'flake8-annotations',
         ]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.10.0
+    rev: v2.11.0
     hooks:
       - id: pyupgrade
         args: [ "--py36-plus", "--py37-plus",'--keep-runtime-typing' ]
   - repo: https://github.com/pycqa/isort
-    rev: 5.7.0
+    rev: 5.8.0
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.800'
+    rev: 'v0.812'
     hooks:
       - id: mypy
         additional_dependencies: [ pytest ]

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -7,13 +7,12 @@ from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from flake8_type_checking.constants import TCH001, TCH002, TCH003, TCHA001, TCHA002, TCHB001, TCHB002
+from flake8_type_checking.constants import TCH001, TCH002, TCH003, TCH004, TCHA001, TCHA002, TCHB001, TCHB002
 
 if TYPE_CHECKING:
     from typing import Any, List, Optional
 
     from flake8_type_checking.types import Flake8Generator, ImportType
-
 
 possible_local_errors = ()
 with suppress(ModuleNotFoundError):
@@ -294,6 +293,8 @@ class TypingOnlyImportsChecker:
             self.unused_third_party_import,
             # TCH003
             self.multiple_type_checking_blocks,
+            # TCH004
+            self.used_type_checking_imports,
             # TCHA001
             self.missing_futures_import,
             # TCHA002
@@ -328,6 +329,12 @@ class TypingOnlyImportsChecker:
         """TCH003."""
         if len([i for i in self.visitor.type_checking_blocks if i[2] == 0]) > 1:
             yield self.visitor.type_checking_blocks[-1][0], 0, TCH003, None
+
+    def used_type_checking_imports(self) -> Flake8Generator:
+        """TCH004."""
+        for _import, import_name in self.visitor.type_checking_block_imports:
+            if import_name in self.visitor.uses:
+                yield _import.lineno, 0, TCH004.format(module=import_name), None
 
     def missing_futures_import(self) -> Flake8Generator:
         """TCHA001."""

--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 TCH001 = "TCH001: Move import '{module}' into a type-checking block"
 TCH002 = "TCH002: Move third-party import '{module}' into a type-checking block"
 TCH003 = 'TCH003: Found multiple type checking blocks'
+TCH004 = "TCH004: Move import '{module}' out of type-checking block. Import is used for more than type hinting."
 TCHA001 = "TCHA001: Add 'from __future__ import annotations' import"
 TCHA002 = "TCHA002: Annotation '{annotation}' does not need to be a string literal"
 TCHB001 = "TCHB001: Annotation '{annotation}' needs to be made into a string literal"

--- a/poetry.lock
+++ b/poetry.lock
@@ -57,7 +57,7 @@ toml = ["toml"]
 
 [[package]]
 name = "decorator"
-version = "4.4.2"
+version = "5.0.0"
 description = "Decorators for Humans"
 category = "dev"
 optional = false
@@ -79,7 +79,7 @@ pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
 name = "importlib-metadata"
-version = "3.7.3"
+version = "3.10.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -91,7 +91,7 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -103,7 +103,7 @@ python-versions = "*"
 
 [[package]]
 name = "ipython"
-version = "7.21.0"
+version = "7.22.0"
 description = "IPython: Productive Interactive Computing"
 category = "dev"
 optional = false
@@ -122,7 +122,7 @@ pygments = "*"
 traitlets = ">=4.2"
 
 [package.extras]
-all = ["Sphinx (>=1.3)", "ipykernel", "ipyparallel", "ipywidgets", "nbconvert", "nbformat", "nose (>=0.10.1)", "notebook", "numpy (>=1.14)", "pygments", "qtconsole", "requests", "testpath"]
+all = ["Sphinx (>=1.3)", "ipykernel", "ipyparallel", "ipywidgets", "nbconvert", "nbformat", "nose (>=0.10.1)", "notebook", "numpy (>=1.16)", "pygments", "qtconsole", "requests", "testpath"]
 doc = ["Sphinx (>=1.3)"]
 kernel = ["ipykernel"]
 nbconvert = ["nbconvert"]
@@ -130,7 +130,7 @@ nbformat = ["nbformat"]
 notebook = ["notebook", "ipywidgets"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
-test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.14)"]
+test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.16)"]
 
 [[package]]
 name = "ipython-genutils"
@@ -176,7 +176,7 @@ pyparsing = ">=2.0.2"
 
 [[package]]
 name = "parso"
-version = "0.8.1"
+version = "0.8.2"
 description = "A Python Parser"
 category = "dev"
 optional = false
@@ -221,7 +221,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.17"
+version = "3.0.18"
 description = "Library for building powerful interactive command lines in Python"
 category = "dev"
 optional = false
@@ -256,7 +256,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyflakes"
-version = "2.3.0"
+version = "2.3.1"
 description = "passive checker of Python programs"
 category = "main"
 optional = false
@@ -443,24 +443,24 @@ coverage = [
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 decorator = [
-    {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
-    {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
+    {file = "decorator-5.0.0-py2.py3-none-any.whl", hash = "sha256:fcb017be35f10951958e0871fb70e553db9cac018e303d748b63fcd60eb70149"},
+    {file = "decorator-5.0.0.tar.gz", hash = "sha256:11f6e1e1ba3e7ffbfd9362da692e65791d6367bfd68ebf07064dd29a6e30f137"},
 ]
 flake8 = [
     {file = "flake8-3.9.0-py2.py3-none-any.whl", hash = "sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff"},
     {file = "flake8-3.9.0.tar.gz", hash = "sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.7.3-py3-none-any.whl", hash = "sha256:b74159469b464a99cb8cc3e21973e4d96e05d3024d337313fedb618a6e86e6f4"},
-    {file = "importlib_metadata-3.7.3.tar.gz", hash = "sha256:742add720a20d0467df2f444ae41704000f50e1234f46174b51f9c6031a1bd71"},
+    {file = "importlib_metadata-3.10.0-py3-none-any.whl", hash = "sha256:d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe"},
+    {file = "importlib_metadata-3.10.0.tar.gz", hash = "sha256:c9db46394197244adf2f0b08ec5bc3cf16757e9590b02af1fca085c16c0d600a"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 ipython = [
-    {file = "ipython-7.21.0-py3-none-any.whl", hash = "sha256:34207ffb2f653bced2bc8e3756c1db86e7d93e44ed049daae9814fed66d408ec"},
-    {file = "ipython-7.21.0.tar.gz", hash = "sha256:04323f72d5b85b606330b6d7e2dc8d2683ad46c3905e955aa96ecc7a99388e70"},
+    {file = "ipython-7.22.0-py3-none-any.whl", hash = "sha256:c0ce02dfaa5f854809ab7413c601c4543846d9da81010258ecdab299b542d199"},
+    {file = "ipython-7.22.0.tar.gz", hash = "sha256:9c900332d4c5a6de534b4befeeb7de44ad0cc42e8327fa41b7685abde58cec74"},
 ]
 ipython-genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
@@ -479,8 +479,8 @@ packaging = [
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
 parso = [
-    {file = "parso-0.8.1-py2.py3-none-any.whl", hash = "sha256:15b00182f472319383252c18d5913b69269590616c947747bc50bf4ac768f410"},
-    {file = "parso-0.8.1.tar.gz", hash = "sha256:8519430ad07087d4c997fda3a7918f7cfa27cb58972a8c89c2a0295a1c940e9e"},
+    {file = "parso-0.8.2-py2.py3-none-any.whl", hash = "sha256:a8c4922db71e4fdb90e0d0bc6e50f9b273d3397925e5e60a717e719201778d22"},
+    {file = "parso-0.8.2.tar.gz", hash = "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398"},
 ]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
@@ -495,8 +495,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.17-py3-none-any.whl", hash = "sha256:4cea7d09e46723885cb8bc54678175453e5071e9449821dce6f017b1d1fbfc1a"},
-    {file = "prompt_toolkit-3.0.17.tar.gz", hash = "sha256:9397a7162cf45449147ad6042fa37983a081b8a73363a5253dd4072666333137"},
+    {file = "prompt_toolkit-3.0.18-py3-none-any.whl", hash = "sha256:bf00f22079f5fadc949f42ae8ff7f05702826a97059ffcc6281036ad40ac6f04"},
+    {file = "prompt_toolkit-3.0.18.tar.gz", hash = "sha256:e1b4f11b9336a28fa11810bc623c357420f69dfdb6d2dac41ca2c21a55c033bc"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -511,8 +511,8 @@ pycodestyle = [
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.3.0-py2.py3-none-any.whl", hash = "sha256:910208209dcea632721cb58363d0f72913d9e8cf64dc6f8ae2e02a3609aba40d"},
-    {file = "pyflakes-2.3.0.tar.gz", hash = "sha256:e59fd8e750e588358f1b8885e5a4751203a0516e0ee6d34811089ac294c8806f"},
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pygments = [
     {file = "Pygments-2.8.1-py3-none-any.whl", hash = "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
     'Typing :: Typed',
 ]
 
+[tool.poetry.urls]
+"Issue Tracker" = "https://github.com/sondrelg/flake8-type-checking/issues"
+
 [tool.poetry.dependencies]
 python = '^3.7'
 flake8 = '*'
@@ -38,7 +41,7 @@ pytest-cov = '^2.11.1'
 
 [tool.poetry.plugins]
 [tool.poetry.plugins.'flake8.extension']
-TCH100 = 'flake8_type_checking:Plugin'
+TCH = 'flake8_type_checking:Plugin'
 
 [build-system]
 requires = ['poetry-core>=1.0.0']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from flake8_type_checking import Plugin
+from flake8_type_checking.plugin import Plugin
 
 REPO_ROOT = Path(os.getcwd()).parent
 mod = 'flake8_type_checking'

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,7 +3,7 @@ Contains special test cases that fall outside the scope of remaining test files.
 """
 import textwrap
 
-from flake8_type_checking.constants import TCH001, TCH002, TCH003, TCHA001
+from flake8_type_checking.constants import TCH001, TCH002, TCH003, TCH004, TCHA001
 from tests import _get_error, mod
 
 
@@ -127,3 +127,20 @@ class TestFoundBugs:
         """
         )
         assert _get_error(example) == {"7:4 TCH002: Move third-party import 'x' into a type-checking block"}
+
+    def test_called_typing_import(self):
+        example = textwrap.dedent(
+            """
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from datetime import datetime
+            from datetime import date
+
+        x = datetime
+
+        def example():
+            return date()
+        """
+        )
+        assert _get_error(example) == {'5:0 ' + TCH004.format(module='datetime'), '6:0 ' + TCH004.format(module='date')}


### PR DESCRIPTION
This seems like the missing piece of the puzzle. 

Not convinced this check is anywhere near robust enough to be used yet, but if we could make this work, that should close the loop on type-checking import management.