### PR TITLE
Resolve failing TC004 test

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -265,6 +265,16 @@ class ImportVisitor(ast.NodeTransformer):
                 if hasattr(argument, 'annotation'):
                     self._add_annotation(argument.annotation)  # type: ignore
                     delattr(argument, 'annotation')
+        if hasattr(node.args, 'kwarg'):
+            kwarg = node.args.kwarg
+            if hasattr(kwarg, 'annotation'):
+                self._add_annotation(kwarg.annotation)  # type: ignore
+                delattr(kwarg, 'annotation')
+        if hasattr(node.args, 'vararg'):
+            vararg = node.args.vararg
+            if hasattr(vararg, 'annotation'):
+                self._add_annotation(vararg.annotation)  # type: ignore
+                delattr(vararg, 'annotation')
         if hasattr(node, 'returns'):
             self._add_annotation(node.returns)  # type: ignore
             delattr(node, 'returns')

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -127,34 +127,3 @@ class TestFoundBugs:
         """
         )
         assert _get_error(example) == {"7:4 TC002: Move third-party import 'x' into a type-checking block"}
-
-    def test_called_typing_import(self):
-        example = textwrap.dedent(
-            """
-        from typing import TYPE_CHECKING
-
-        if TYPE_CHECKING:
-            from datetime import datetime
-            from datetime import date
-
-        x = datetime
-
-        def example():
-            return date()
-        """
-        )
-        assert _get_error(example) == {'5:0 ' + TC004.format(module='datetime'), '6:0 ' + TC004.format(module='date')}
-
-    def test_failing_TC004(self):
-        example = textwrap.dedent(
-            """
-        from typing import TYPE_CHECKING
-
-        if TYPE_CHECKING:
-            from typing import Any
-
-        def example(**kwargs: Any):
-            return
-        """
-        )
-        assert _get_error(example, error_code_filter='TC004') == set()

--- a/tests/test_tc004.py
+++ b/tests/test_tc004.py
@@ -1,0 +1,64 @@
+"""
+This file tests the TC004 error:
+
+    >> Move import out of type-checking block. Import is used for more than type hinting.
+
+"""
+import textwrap
+
+import pytest
+
+from flake8_type_checking.constants import TC004
+from tests import _get_error
+
+examples = [
+    # No error
+    ('', set()),
+    # Used in file
+    (
+        textwrap.dedent(
+            """
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from datetime import datetime
+
+    x = datetime
+    """
+        ),
+        {'5:0 ' + TC004.format(module='datetime')},
+    ),
+    # Used in function
+    (
+        textwrap.dedent(
+            """
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from datetime import date
+
+    def example():
+        return date()
+    """
+        ),
+        {'5:0 ' + TC004.format(module='date')},
+    ),
+    # Used for typing only
+    (
+        textwrap.dedent(
+            """
+    if TYPE_CHECKING:
+        from typing import Any
+
+    def example(*args: Any, **kwargs: Any):
+        return
+    """
+        ),
+        set(),
+    ),
+]
+
+
+@pytest.mark.parametrize('example, expected', examples)
+def test_TC004_errors(example, expected):
+    assert _get_error(example, error_code_filter='TC004') == expected


### PR DESCRIPTION
Turns out we hadn't yet handled `*args` and `**kwargs` style type annotations, which lead to false `TC004` positives